### PR TITLE
Fix code scanning alert no. 181: Code injection

### DIFF
--- a/external-tools/Obsolete/AtomViewer/WebContent/lib/dojo/dojo/_base/json.js
+++ b/external-tools/Obsolete/AtomViewer/WebContent/lib/dojo/dojo/_base/json.js
@@ -7,7 +7,7 @@
 //>>built
 define("dojo/_base/json",["./kernel","../json"],function(_1,_2){
 _1.fromJson=function(js){
-return eval("("+js+")");
+return JSON.parse(js);
 };
 _1._escapeString=_2.stringify;
 _1.toJsonIndentStr="\t";


### PR DESCRIPTION
Fixes [https://github.com/ZoneCog/opencog-central/security/code-scanning/181](https://github.com/ZoneCog/opencog-central/security/code-scanning/181)

To fix the problem, we should avoid using `eval` to parse JSON strings. Instead, we can use the built-in `JSON.parse` method, which is safer and does not execute arbitrary code. This change will ensure that the input is treated strictly as JSON data and not as executable code.

- Replace the `eval` call with `JSON.parse`.
- Ensure that the change is made in the `fromJson` function in the `external-tools/Obsolete/AtomViewer/WebContent/lib/dojo/dojo/_base/json.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
